### PR TITLE
Add text field to static questionnaire

### DIFF
--- a/public/static/mcode-questionnaire.json
+++ b/public/static/mcode-questionnaire.json
@@ -1,12 +1,12 @@
 {
   "resourceType": "Questionnaire",
-  "id": "HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1",
-  "title": "HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1",
+  "id": "mcode",
+  "title": "mcode",
   "status": "draft",
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/cqf-library",
-      "valueCanonical": "Library/HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1"
+      "valueCanonical": "Library/mcode"
     }
   ],
   "item": [
@@ -18,7 +18,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".CancerDiseaseStatus"
+            "expression": "\"mcode\".CancerDiseaseStatus"
           }
         }
       ],
@@ -32,7 +32,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".CancerGeneticVariant"
+            "expression": "\"mcode\".CancerGeneticVariant"
           }
         }
       ],
@@ -46,7 +46,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".CancerGenomicsReport"
+            "expression": "\"mcode\".CancerGenomicsReport"
           }
         }
       ],
@@ -60,7 +60,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".CancerRelatedRadiationProcedure"
+            "expression": "\"mcode\".CancerRelatedRadiationProcedure"
           }
         }
       ],
@@ -74,7 +74,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".CancerRelatedSurgicalProcedure"
+            "expression": "\"mcode\".CancerRelatedSurgicalProcedure"
           }
         }
       ],
@@ -88,7 +88,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".ComorbidCondition"
+            "expression": "\"mcode\".ComorbidCondition"
           }
         }
       ],
@@ -102,7 +102,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".ECOGPerformanceStatus"
+            "expression": "\"mcode\".ECOGPerformanceStatus"
           }
         }
       ],
@@ -116,7 +116,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".GeneticSpecimen"
+            "expression": "\"mcode\".GeneticSpecimen"
           }
         }
       ],
@@ -130,7 +130,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".GenomicRegionStudied"
+            "expression": "\"mcode\".GenomicRegionStudied"
           }
         }
       ],
@@ -144,7 +144,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".KarnofskyPerformanceStatus"
+            "expression": "\"mcode\".KarnofskyPerformanceStatus"
           }
         }
       ],
@@ -158,7 +158,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".PrimaryCancerCondition"
+            "expression": "\"mcode\".PrimaryCancerCondition"
           }
         }
       ],
@@ -172,7 +172,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".SecondaryCancerCondition"
+            "expression": "\"mcode\".SecondaryCancerCondition"
           }
         }
       ],
@@ -186,7 +186,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TNMClinicalDistantMetastasesCategory"
+            "expression": "\"mcode\".TNMClinicalDistantMetastasesCategory"
           }
         }
       ],
@@ -200,7 +200,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TNMClinicalPrimaryTumorCategory"
+            "expression": "\"mcode\".TNMClinicalPrimaryTumorCategory"
           }
         }
       ],
@@ -214,7 +214,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TNMClinicalRegionalNodesCategory"
+            "expression": "\"mcode\".TNMClinicalRegionalNodesCategory"
           }
         }
       ],
@@ -228,7 +228,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TNMClinicalStageGroup"
+            "expression": "\"mcode\".TNMClinicalStageGroup"
           }
         }
       ],
@@ -242,7 +242,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TNMPathologicalDistantMetastasesCategory"
+            "expression": "\"mcode\".TNMPathologicalDistantMetastasesCategory"
           }
         }
       ],
@@ -256,7 +256,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TNMPathologicalPrimaryTumorCategory"
+            "expression": "\"mcode\".TNMPathologicalPrimaryTumorCategory"
           }
         }
       ],
@@ -270,7 +270,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TNMPathologicalRegionalNodesCategory"
+            "expression": "\"mcode\".TNMPathologicalRegionalNodesCategory"
           }
         }
       ],
@@ -284,7 +284,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TNMPathologicalStageGroup"
+            "expression": "\"mcode\".TNMPathologicalStageGroup"
           }
         }
       ],
@@ -298,7 +298,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TumorMarker"
+            "expression": "\"mcode\".TumorMarker"
           }
         }
       ],

--- a/public/static/mcode-questionnaire.json
+++ b/public/static/mcode-questionnaire.json
@@ -1,23 +1,24 @@
 {
   "resourceType": "Questionnaire",
-  "id": "mcode",
-  "title": "mcode",
+  "id": "HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1",
+  "title": "HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1",
   "status": "draft",
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/cqf-library",
-      "valueCanonical": "./static/mcode-library.json"
+      "valueCanonical": "Library/HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1"
     }
   ],
   "item": [
     {
       "linkId": "CancerDiseaseStatus",
+      "text": "CancerDiseaseStatus",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".CancerDiseaseStatus"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".CancerDiseaseStatus"
           }
         }
       ],
@@ -25,12 +26,13 @@
     },
     {
       "linkId": "CancerGeneticVariant",
+      "text": "CancerGeneticVariant",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".CancerGeneticVariant"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".CancerGeneticVariant"
           }
         }
       ],
@@ -38,12 +40,13 @@
     },
     {
       "linkId": "CancerGenomicsReport",
+      "text": "CancerGenomicsReport",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".CancerGenomicsReport"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".CancerGenomicsReport"
           }
         }
       ],
@@ -51,12 +54,13 @@
     },
     {
       "linkId": "CancerRelatedRadiationProcedure",
+      "text": "CancerRelatedRadiationProcedure",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".CancerRelatedRadiationProcedure"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".CancerRelatedRadiationProcedure"
           }
         }
       ],
@@ -64,12 +68,13 @@
     },
     {
       "linkId": "CancerRelatedSurgicalProcedure",
+      "text": "CancerRelatedSurgicalProcedure",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".CancerRelatedSurgicalProcedure"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".CancerRelatedSurgicalProcedure"
           }
         }
       ],
@@ -77,12 +82,13 @@
     },
     {
       "linkId": "ComorbidCondition",
+      "text": "ComorbidCondition",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".ComorbidCondition"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".ComorbidCondition"
           }
         }
       ],
@@ -90,12 +96,13 @@
     },
     {
       "linkId": "ECOGPerformanceStatus",
+      "text": "ECOGPerformanceStatus",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".ECOGPerformanceStatus"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".ECOGPerformanceStatus"
           }
         }
       ],
@@ -103,12 +110,13 @@
     },
     {
       "linkId": "GeneticSpecimen",
+      "text": "GeneticSpecimen",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".GeneticSpecimen"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".GeneticSpecimen"
           }
         }
       ],
@@ -116,12 +124,13 @@
     },
     {
       "linkId": "GenomicRegionStudied",
+      "text": "GenomicRegionStudied",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".GenomicRegionStudied"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".GenomicRegionStudied"
           }
         }
       ],
@@ -129,12 +138,13 @@
     },
     {
       "linkId": "KarnofskyPerformanceStatus",
+      "text": "KarnofskyPerformanceStatus",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".KarnofskyPerformanceStatus"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".KarnofskyPerformanceStatus"
           }
         }
       ],
@@ -142,12 +152,13 @@
     },
     {
       "linkId": "PrimaryCancerCondition",
+      "text": "PrimaryCancerCondition",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".PrimaryCancerCondition"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".PrimaryCancerCondition"
           }
         }
       ],
@@ -155,12 +166,13 @@
     },
     {
       "linkId": "SecondaryCancerCondition",
+      "text": "SecondaryCancerCondition",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".SecondaryCancerCondition"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".SecondaryCancerCondition"
           }
         }
       ],
@@ -168,12 +180,13 @@
     },
     {
       "linkId": "TNMClinicalDistantMetastasesCategory",
+      "text": "TNMClinicalDistantMetastasesCategory",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".TNMClinicalDistantMetastasesCategory"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TNMClinicalDistantMetastasesCategory"
           }
         }
       ],
@@ -181,12 +194,13 @@
     },
     {
       "linkId": "TNMClinicalPrimaryTumorCategory",
+      "text": "TNMClinicalPrimaryTumorCategory",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".TNMClinicalPrimaryTumorCategory"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TNMClinicalPrimaryTumorCategory"
           }
         }
       ],
@@ -194,12 +208,13 @@
     },
     {
       "linkId": "TNMClinicalRegionalNodesCategory",
+      "text": "TNMClinicalRegionalNodesCategory",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".TNMClinicalRegionalNodesCategory"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TNMClinicalRegionalNodesCategory"
           }
         }
       ],
@@ -207,12 +222,13 @@
     },
     {
       "linkId": "TNMClinicalStageGroup",
+      "text": "TNMClinicalStageGroup",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".TNMClinicalStageGroup"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TNMClinicalStageGroup"
           }
         }
       ],
@@ -220,12 +236,13 @@
     },
     {
       "linkId": "TNMPathologicalDistantMetastasesCategory",
+      "text": "TNMPathologicalDistantMetastasesCategory",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".TNMPathologicalDistantMetastasesCategory"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TNMPathologicalDistantMetastasesCategory"
           }
         }
       ],
@@ -233,12 +250,13 @@
     },
     {
       "linkId": "TNMPathologicalPrimaryTumorCategory",
+      "text": "TNMPathologicalPrimaryTumorCategory",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".TNMPathologicalPrimaryTumorCategory"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TNMPathologicalPrimaryTumorCategory"
           }
         }
       ],
@@ -246,12 +264,13 @@
     },
     {
       "linkId": "TNMPathologicalRegionalNodesCategory",
+      "text": "TNMPathologicalRegionalNodesCategory",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".TNMPathologicalRegionalNodesCategory"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TNMPathologicalRegionalNodesCategory"
           }
         }
       ],
@@ -259,12 +278,13 @@
     },
     {
       "linkId": "TNMPathologicalStageGroup",
+      "text": "TNMPathologicalStageGroup",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".TNMPathologicalStageGroup"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TNMPathologicalStageGroup"
           }
         }
       ],
@@ -272,12 +292,13 @@
     },
     {
       "linkId": "TumorMarker",
+      "text": "TumorMarker",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".TumorMarker"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TumorMarker"
           }
         }
       ],

--- a/public/static/mcode-questionnaire.json
+++ b/public/static/mcode-questionnaire.json
@@ -6,7 +6,7 @@
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/cqf-library",
-      "valueCanonical": "Library/mcode"
+      "valueCanonical": "./static/mcode-library.json"
     }
   ],
   "item": [


### PR DESCRIPTION
Updated `public/static/mcode-questionnaire.json` to reflect changes to the questionnaire output from ig-questionnaire repository. The questionnaire fixture now includes a `text` field for each questionnaire item.

Test:
Each item in the the React App questionnaire should now show the name of an mCODE resource.