### PR TITLE
Link results to questionnaire

### DIFF
--- a/public/static/mcode-questionnaire.json
+++ b/public/static/mcode-questionnaire.json
@@ -1,12 +1,12 @@
 {
   "resourceType": "Questionnaire",
-  "id": "HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1",
-  "title": "HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1",
+  "id": "mcode",
+  "title": "mcode",
   "status": "draft",
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/cqf-library",
-      "valueCanonical": "Library/HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1"
+      "valueCanonical": "Library/mcode"
     }
   ],
   "item": [
@@ -18,7 +18,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".CancerDiseaseStatus"
+            "expression": "\"mcode\".CancerDiseaseStatus"
           }
         }
       ],
@@ -32,7 +32,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".CancerGeneticVariant"
+            "expression": "\"mcode\".CancerGeneticVariant"
           }
         }
       ],
@@ -46,7 +46,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".CancerGenomicsReport"
+            "expression": "\"mcode\".CancerGenomicsReport"
           }
         }
       ],
@@ -60,7 +60,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".CancerRelatedRadiationProcedure"
+            "expression": "\"mcode\".CancerRelatedRadiationProcedure"
           }
         }
       ],
@@ -74,7 +74,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".CancerRelatedSurgicalProcedure"
+            "expression": "\"mcode\".CancerRelatedSurgicalProcedure"
           }
         }
       ],
@@ -88,7 +88,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".ComorbidCondition"
+            "expression": "\"mcode\".ComorbidCondition"
           }
         }
       ],
@@ -102,7 +102,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".ECOGPerformanceStatus"
+            "expression": "\"mcode\".ECOGPerformanceStatus"
           }
         }
       ],
@@ -116,7 +116,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".GeneticSpecimen"
+            "expression": "\"mcode\".GeneticSpecimen"
           }
         }
       ],
@@ -130,7 +130,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".GenomicRegionStudied"
+            "expression": "\"mcode\".GenomicRegionStudied"
           }
         }
       ],
@@ -144,7 +144,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".KarnofskyPerformanceStatus"
+            "expression": "\"mcode\".KarnofskyPerformanceStatus"
           }
         }
       ],
@@ -158,7 +158,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".PrimaryCancerCondition"
+            "expression": "\"mcode\".PrimaryCancerCondition"
           }
         }
       ],
@@ -172,7 +172,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".SecondaryCancerCondition"
+            "expression": "\"mcode\".SecondaryCancerCondition"
           }
         }
       ],
@@ -186,7 +186,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TNMClinicalDistantMetastasesCategory"
+            "expression": "\"mcode\".TNMClinicalDistantMetastasesCategory"
           }
         }
       ],
@@ -200,7 +200,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TNMClinicalPrimaryTumorCategory"
+            "expression": "\"mcode\".TNMClinicalPrimaryTumorCategory"
           }
         }
       ],
@@ -214,7 +214,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TNMClinicalRegionalNodesCategory"
+            "expression": "\"mcode\".TNMClinicalRegionalNodesCategory"
           }
         }
       ],
@@ -228,7 +228,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TNMClinicalStageGroup"
+            "expression": "\"mcode\".TNMClinicalStageGroup"
           }
         }
       ],
@@ -242,7 +242,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TNMPathologicalDistantMetastasesCategory"
+            "expression": "\"mcode\".TNMPathologicalDistantMetastasesCategory"
           }
         }
       ],
@@ -256,7 +256,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TNMPathologicalPrimaryTumorCategory"
+            "expression": "\"mcode\".TNMPathologicalPrimaryTumorCategory"
           }
         }
       ],
@@ -270,7 +270,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TNMPathologicalRegionalNodesCategory"
+            "expression": "\"mcode\".TNMPathologicalRegionalNodesCategory"
           }
         }
       ],
@@ -284,7 +284,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TNMPathologicalStageGroup"
+            "expression": "\"mcode\".TNMPathologicalStageGroup"
           }
         }
       ],
@@ -298,7 +298,7 @@
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TumorMarker"
+            "expression": "\"mcode\".TumorMarker"
           }
         }
       ],

--- a/public/static/mcode-questionnaire.json
+++ b/public/static/mcode-questionnaire.json
@@ -1,23 +1,24 @@
 {
   "resourceType": "Questionnaire",
-  "id": "mcode",
-  "title": "mcode",
+  "id": "HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1",
+  "title": "HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1",
   "status": "draft",
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/cqf-library",
-      "valueCanonical": "./static/mcode-library.json"
+      "valueCanonical": "Library/HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1"
     }
   ],
   "item": [
     {
       "linkId": "CancerDiseaseStatus",
+      "text": "CancerDiseaseStatus",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".CancerDiseaseStatus"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".CancerDiseaseStatus"
           }
         }
       ],
@@ -25,12 +26,13 @@
     },
     {
       "linkId": "CancerGeneticVariant",
+      "text": "CancerGeneticVariant",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".CancerGeneticVariant"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".CancerGeneticVariant"
           }
         }
       ],
@@ -38,12 +40,13 @@
     },
     {
       "linkId": "CancerGenomicsReport",
+      "text": "CancerGenomicsReport",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".CancerGenomicsReport"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".CancerGenomicsReport"
           }
         }
       ],
@@ -51,12 +54,13 @@
     },
     {
       "linkId": "CancerRelatedRadiationProcedure",
+      "text": "CancerRelatedRadiationProcedure",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".CancerRelatedRadiationProcedure"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".CancerRelatedRadiationProcedure"
           }
         }
       ],
@@ -64,12 +68,13 @@
     },
     {
       "linkId": "CancerRelatedSurgicalProcedure",
+      "text": "CancerRelatedSurgicalProcedure",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".CancerRelatedSurgicalProcedure"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".CancerRelatedSurgicalProcedure"
           }
         }
       ],
@@ -77,12 +82,13 @@
     },
     {
       "linkId": "ComorbidCondition",
+      "text": "ComorbidCondition",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".ComorbidCondition"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".ComorbidCondition"
           }
         }
       ],
@@ -90,12 +96,13 @@
     },
     {
       "linkId": "ECOGPerformanceStatus",
+      "text": "ECOGPerformanceStatus",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".ECOGPerformanceStatus"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".ECOGPerformanceStatus"
           }
         }
       ],
@@ -103,12 +110,13 @@
     },
     {
       "linkId": "GeneticSpecimen",
+      "text": "GeneticSpecimen",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".GeneticSpecimen"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".GeneticSpecimen"
           }
         }
       ],
@@ -116,12 +124,13 @@
     },
     {
       "linkId": "GenomicRegionStudied",
+      "text": "GenomicRegionStudied",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".GenomicRegionStudied"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".GenomicRegionStudied"
           }
         }
       ],
@@ -129,12 +138,13 @@
     },
     {
       "linkId": "KarnofskyPerformanceStatus",
+      "text": "KarnofskyPerformanceStatus",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".KarnofskyPerformanceStatus"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".KarnofskyPerformanceStatus"
           }
         }
       ],
@@ -142,12 +152,13 @@
     },
     {
       "linkId": "PrimaryCancerCondition",
+      "text": "PrimaryCancerCondition",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".PrimaryCancerCondition"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".PrimaryCancerCondition"
           }
         }
       ],
@@ -155,12 +166,13 @@
     },
     {
       "linkId": "SecondaryCancerCondition",
+      "text": "SecondaryCancerCondition",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".SecondaryCancerCondition"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".SecondaryCancerCondition"
           }
         }
       ],
@@ -168,12 +180,13 @@
     },
     {
       "linkId": "TNMClinicalDistantMetastasesCategory",
+      "text": "TNMClinicalDistantMetastasesCategory",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".TNMClinicalDistantMetastasesCategory"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TNMClinicalDistantMetastasesCategory"
           }
         }
       ],
@@ -181,12 +194,13 @@
     },
     {
       "linkId": "TNMClinicalPrimaryTumorCategory",
+      "text": "TNMClinicalPrimaryTumorCategory",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".TNMClinicalPrimaryTumorCategory"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TNMClinicalPrimaryTumorCategory"
           }
         }
       ],
@@ -194,12 +208,13 @@
     },
     {
       "linkId": "TNMClinicalRegionalNodesCategory",
+      "text": "TNMClinicalRegionalNodesCategory",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".TNMClinicalRegionalNodesCategory"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TNMClinicalRegionalNodesCategory"
           }
         }
       ],
@@ -207,12 +222,13 @@
     },
     {
       "linkId": "TNMClinicalStageGroup",
+      "text": "TNMClinicalStageGroup",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".TNMClinicalStageGroup"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TNMClinicalStageGroup"
           }
         }
       ],
@@ -220,12 +236,13 @@
     },
     {
       "linkId": "TNMPathologicalDistantMetastasesCategory",
+      "text": "TNMPathologicalDistantMetastasesCategory",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".TNMPathologicalDistantMetastasesCategory"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TNMPathologicalDistantMetastasesCategory"
           }
         }
       ],
@@ -233,12 +250,13 @@
     },
     {
       "linkId": "TNMPathologicalPrimaryTumorCategory",
+      "text": "TNMPathologicalPrimaryTumorCategory",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".TNMPathologicalPrimaryTumorCategory"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TNMPathologicalPrimaryTumorCategory"
           }
         }
       ],
@@ -246,12 +264,13 @@
     },
     {
       "linkId": "TNMPathologicalRegionalNodesCategory",
+      "text": "TNMPathologicalRegionalNodesCategory",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".TNMPathologicalRegionalNodesCategory"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TNMPathologicalRegionalNodesCategory"
           }
         }
       ],
@@ -259,12 +278,13 @@
     },
     {
       "linkId": "TNMPathologicalStageGroup",
+      "text": "TNMPathologicalStageGroup",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".TNMPathologicalStageGroup"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TNMPathologicalStageGroup"
           }
         }
       ],
@@ -272,12 +292,13 @@
     },
     {
       "linkId": "TumorMarker",
+      "text": "TumorMarker",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"mcode\".TumorMarker"
+            "expression": "\"HL7FHIRImplementationGuideminimalCommonOncologyDataElementsmCODERelease1USRealmSTU1\".TumorMarker"
           }
         }
       ],

--- a/public/static/mcode-questionnaire.json
+++ b/public/static/mcode-questionnaire.json
@@ -6,7 +6,7 @@
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/cqf-library",
-      "valueCanonical": "Library/mcode"
+      "valueCanonical": "./static/mcode-library.json"
     }
   ],
   "item": [

--- a/src/components/Abstractor/Abstractor.tsx
+++ b/src/components/Abstractor/Abstractor.tsx
@@ -6,7 +6,7 @@ import { QuestionnaireLoader } from '../../loaders/QuestionnaireLoader';
 import { LibraryLoader } from '../../loaders/libraryLoader';
 import executeElm from '../../utils/cql-executor';
 import { ValueSetLoader } from '../../loaders/ValueSetLoader';
-// import resultsProcessing from '../../utils/results-processing';
+import resultsProcessing from '../../utils/results-processing';
 
 //const defaultQuestionnaire: R4.IQuestionnaire = {
 //resourceType: 'Questionnaire',
@@ -46,10 +46,11 @@ const Abstractor = () => {
 
           // TODO: Modify the answerOptions of the questionnaire to include the results from execution
           const results = executeElm(patientData!, library, valueSetMap);
-          console.log(results);
+          //console.log(results);
 
           // TODO: Filter results by querying proper data from the returned FHIR resources.
-          //const filteredResults = resultsProcessing(results);
+          const filteredResults = resultsProcessing(results);
+          console.log(filteredResults)
 
           //setExecutionResults(results);
         }

--- a/src/components/Abstractor/Abstractor.tsx
+++ b/src/components/Abstractor/Abstractor.tsx
@@ -17,8 +17,8 @@ const Abstractor = ({ patientData, library, valueSetMap, questionnaire }: Props)
     const results = executeElm(patientData!, library, valueSetMap);
 
     // Get Patient ID
-    const patientID = patientData.entry;
-    console.log(patientID);
+    //const patientID = patientData.entry;
+    //console.log(patientID);
 
     const updatedQuestionnaire = questionnaireUpdater(results, questionnaire);
     // Temporary console log to show questionnaire with answer options

--- a/src/components/Abstractor/Abstractor.tsx
+++ b/src/components/Abstractor/Abstractor.tsx
@@ -17,10 +17,10 @@ const Abstractor = ({ patientData, library, valueSetMap, questionnaire }: Props)
     const results = executeElm(patientData!, library, valueSetMap);
 
     // Get Patient ID
-    //const patientID = patientData.entry;
-    //console.log(patientID);
+    const patientResource: any = patientData.entry!.find((bundleResource: any) => bundleResource.resource.resourceType === "Patient");
+    const patientID = patientResource.resource.id;
 
-    const updatedQuestionnaire = questionnaireUpdater(results, questionnaire);
+    const updatedQuestionnaire = questionnaireUpdater(results, questionnaire, patientID);
     // Temporary console log to show questionnaire with answer options
     console.log(updatedQuestionnaire);
 

--- a/src/components/Abstractor/Abstractor.tsx
+++ b/src/components/Abstractor/Abstractor.tsx
@@ -6,7 +6,7 @@ import { QuestionnaireLoader } from '../../loaders/QuestionnaireLoader';
 import { LibraryLoader } from '../../loaders/libraryLoader';
 import executeElm from '../../utils/cql-executor';
 import { ValueSetLoader } from '../../loaders/ValueSetLoader';
-import resultsProcessing from '../../utils/results-processing';
+import questionnaireUpdater from '../../utils/results-processing';
 
 //const defaultQuestionnaire: R4.IQuestionnaire = {
 //resourceType: 'Questionnaire',
@@ -25,11 +25,6 @@ const Abstractor = () => {
       const url = './static/mcode-questionnaire.json';
       try {
         const questionnaireResource = await questionnaireLoader.getFromUrl(url);
-        console.log(questionnaireResource);
-        const lform = window.LForms.Util.convertFHIRQuestionnaireToLForms(questionnaireResource, 'R4');
-        console.log(lform)
-        window.LForms.Util.addFormToPage(lform, 'formContainer');
-        //setQuestionnaire(questionnaireResource);
 
         // Get FHIR Library
         const extension = (questionnaireResource as R4.IQuestionnaire).extension?.find(
@@ -46,13 +41,19 @@ const Abstractor = () => {
           const valueSetLoader = new ValueSetLoader(fhirLibrary, valueSetBundle);
           const valueSetMap = await valueSetLoader.seedValueSets();
 
-          // TODO: Modify the answerOptions of the questionnaire to include the results from execution
           const results = executeElm(patientData!, library, valueSetMap);
           //console.log(results);
 
           // TODO: Filter results by querying proper data from the returned FHIR resources.
-          const filteredResults = resultsProcessing(results);
+          // TODO: Modify the answerOptions of the questionnaire to include the results from execution
+          const filteredResults = questionnaireUpdater(results, questionnaireResource);
           console.log(filteredResults)
+
+          const lform = window.LForms.Util.convertFHIRQuestionnaireToLForms(questionnaireResource, 'R4');
+          window.LForms.Util.addFormToPage(lform, 'formContainer');
+          //setQuestionnaire(questionnaireResource);
+
+
 
           //setExecutionResults(results);
         }

--- a/src/components/Abstractor/Abstractor.tsx
+++ b/src/components/Abstractor/Abstractor.tsx
@@ -25,7 +25,9 @@ const Abstractor = () => {
       const url = './static/mcode-questionnaire.json';
       try {
         const questionnaireResource = await questionnaireLoader.getFromUrl(url);
+        console.log(questionnaireResource);
         const lform = window.LForms.Util.convertFHIRQuestionnaireToLForms(questionnaireResource, 'R4');
+        console.log(lform)
         window.LForms.Util.addFormToPage(lform, 'formContainer');
         //setQuestionnaire(questionnaireResource);
 

--- a/src/components/Abstractor/Abstractor.tsx
+++ b/src/components/Abstractor/Abstractor.tsx
@@ -14,19 +14,23 @@ export interface Props {
 const Abstractor = ({ patientData, library, valueSetMap, questionnaire }: Props) => {
   useEffect(() => {
 
-    const results = executeElm(patientData!, library, valueSetMap);
+    const results = executeElm(patientData, library, valueSetMap);
 
-    // Get Patient ID
-    const patientResource = patientData.entry!.find(
-      (bundleEntry: R4.IBundle_Entry) => bundleEntry.resource!.resourceType === "Patient") as R4.IBundle_Entry;
-    const patientID = patientResource.resource!.id as string;
+    try {
+      // Get Patient ID
+      const patientResource = patientData.entry!.find(
+        (bundleEntry: R4.IBundle_Entry) => bundleEntry.resource!.resourceType === "Patient") as R4.IBundle_Entry;
+      const patientID = patientResource.resource!.id as string;
 
-    const updatedQuestionnaire = questionnaireUpdater(results, questionnaire, patientID);
-    // Temporary console log to show questionnaire with answer options
-    console.log(updatedQuestionnaire);
+      const updatedQuestionnaire = questionnaireUpdater(results, questionnaire, patientID);
+      // Temporary console log to show questionnaire with answer options
+      console.log(updatedQuestionnaire);
 
     const lform = window.LForms.Util.convertFHIRQuestionnaireToLForms(updatedQuestionnaire, 'R4');
     window.LForms.Util.addFormToPage(lform, 'formContainer');
+  } catch (e) {
+    console.error(`Error finding patient resource within bundle: ${e.message}`);
+  }
 
   }, [patientData, library, valueSetMap, questionnaire]);
 

--- a/src/components/Abstractor/Abstractor.tsx
+++ b/src/components/Abstractor/Abstractor.tsx
@@ -43,9 +43,8 @@ const Abstractor = () => {
 
           const results = executeElm(patientData!, library, valueSetMap);
 
-          // TODO: Filter results by querying proper data from the returned FHIR resources.
-          // TODO: Modify the answerOptions of the questionnaire to include the results from execution
           const updatedQuestionnaire = questionnaireUpdater(results, questionnaireResource);
+          console.log(updatedQuestionnaire);
 
           const lform = window.LForms.Util.convertFHIRQuestionnaireToLForms(updatedQuestionnaire, 'R4');
           window.LForms.Util.addFormToPage(lform, 'formContainer');

--- a/src/components/Abstractor/Abstractor.tsx
+++ b/src/components/Abstractor/Abstractor.tsx
@@ -17,8 +17,9 @@ const Abstractor = ({ patientData, library, valueSetMap, questionnaire }: Props)
     const results = executeElm(patientData!, library, valueSetMap);
 
     // Get Patient ID
-    const patientResource: any = patientData.entry!.find((bundleResource: any) => bundleResource.resource.resourceType === "Patient");
-    const patientID = patientResource.resource.id;
+    const patientResource = patientData.entry!.find(
+      (bundleEntry: R4.IBundle_Entry) => bundleEntry.resource!.resourceType === "Patient") as R4.IBundle_Entry;
+    const patientID = patientResource.resource!.id as string;
 
     const updatedQuestionnaire = questionnaireUpdater(results, questionnaire, patientID);
     // Temporary console log to show questionnaire with answer options

--- a/src/components/Abstractor/Abstractor.tsx
+++ b/src/components/Abstractor/Abstractor.tsx
@@ -44,6 +44,7 @@ const Abstractor = () => {
           const results = executeElm(patientData!, library, valueSetMap);
 
           const updatedQuestionnaire = questionnaireUpdater(results, questionnaireResource);
+          // Temporary console log to show questionnaire with answer options
           console.log(updatedQuestionnaire);
 
           const lform = window.LForms.Util.convertFHIRQuestionnaireToLForms(updatedQuestionnaire, 'R4');

--- a/src/components/Abstractor/Abstractor.tsx
+++ b/src/components/Abstractor/Abstractor.tsx
@@ -42,18 +42,14 @@ const Abstractor = () => {
           const valueSetMap = await valueSetLoader.seedValueSets();
 
           const results = executeElm(patientData!, library, valueSetMap);
-          //console.log(results);
 
           // TODO: Filter results by querying proper data from the returned FHIR resources.
           // TODO: Modify the answerOptions of the questionnaire to include the results from execution
-          const filteredResults = questionnaireUpdater(results, questionnaireResource);
-          console.log(filteredResults)
+          const updatedQuestionnaire = questionnaireUpdater(results, questionnaireResource);
 
-          const lform = window.LForms.Util.convertFHIRQuestionnaireToLForms(questionnaireResource, 'R4');
+          const lform = window.LForms.Util.convertFHIRQuestionnaireToLForms(updatedQuestionnaire, 'R4');
           window.LForms.Util.addFormToPage(lform, 'formContainer');
           //setQuestionnaire(questionnaireResource);
-
-
 
           //setExecutionResults(results);
         }

--- a/src/components/Abstractor/__tests__/Abstractor.test.tsx
+++ b/src/components/Abstractor/__tests__/Abstractor.test.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import Abstractor, { Props } from '../Abstractor';
+import bundle from '../../../__tests__/fixtures/sample-patient-bundle.json';
+import { R4 } from '@ahryman40k/ts-fhir-types';
 
 const defaultProps: Props = {
-  patientData: {
-    resourceType: 'Bundle',
-    entry: []
-  },
+  patientData: bundle as R4.IBundle,
   library: null,
   valueSetMap: {},
   questionnaire: {

--- a/src/utils/results-processing.ts
+++ b/src/utils/results-processing.ts
@@ -8,25 +8,28 @@ export default function questionnaireUpdater(
   patientId: string
 ): R4.IQuestionnaire {
   // Object Containing Questionnaire Items
-  let questionnaireItems: any = questionnaire.item;
+  let questionnaireItems = questionnaire.item;
 
-  // Get Non-Empty Patient Results
-  const igResources = cqlResults.patientResults[patientId];
-  for (let key in igResources) {
-    let resourceList = igResources[key];
-    if (resourceList.length > 0) {
-      // Find corresponding quesionnaire resource
-      const matchingResource = questionnaireItems.find(element => element.linkId === key);
-      const questionnaireItemIndex = questionnaireItems.indexOf(matchingResource);
+  if (questionnaireItems !== undefined){
+    // Get Non-Empty Patient Results
+    const igResources = cqlResults.patientResults[patientId];
+    for (let key in igResources) {
+      let resourceList = igResources[key];
+      console.log(resourceList);
+      if (resourceList.length > 0) {
+        // Find corresponding quesionnaire resource
+        const matchingResource = questionnaireItems.find(element => element.linkId === key) as R4.IQuestionnaire_Item;
+        const questionnaireItemIndex = questionnaireItems.indexOf(matchingResource);
 
-      // Add answerOption element to questionnaire item
-      const newAnswerOptions = resourceList.map(createAnswerOption);
-      if (matchingResource.answerOption === undefined || matchingResource.answerOption.length === 0) {
-        matchingResource.answerOption = newAnswerOptions;
-      } else {
-        matchingResource.answerOption = matchingResource.answerOption.concat(newAnswerOptions);
+        // Add answerOption element to questionnaire item
+        const newAnswerOptions = resourceList.map(createAnswerOption);
+        if (matchingResource.answerOption === undefined || matchingResource.answerOption.length === 0) {
+          matchingResource.answerOption = newAnswerOptions;
+        } else {
+          matchingResource.answerOption = matchingResource.answerOption.concat(newAnswerOptions);
+        }
+        questionnaireItems[questionnaireItemIndex] = matchingResource;
       }
-      questionnaireItems[questionnaireItemIndex] = matchingResource;
     }
   }
 
@@ -34,7 +37,7 @@ export default function questionnaireUpdater(
   return questionnaire;
 }
 
-function createAnswerOption(fhirObject: any) {
+function createAnswerOption(fhirObject: any): R4.IQuestionnaire_AnswerOption {
   const referenceLocation = `${fhirObject._json.resourceType}/${fhirObject.id.value}`;
   // Format answer option
   const referenceObject = {

--- a/src/utils/results-processing.ts
+++ b/src/utils/results-processing.ts
@@ -1,10 +1,11 @@
 import { R4 } from "@ahryman40k/ts-fhir-types";
 
-export default function questionnaireUpdater(cqlResults: any, questionnaire: R4.IQuestionnaire): any {
+// Filter results by querying proper data from the returned FHIR resources.
+// Modify the answerOptions of the questionnaire to include the results from execution
+export default function questionnaireUpdater(cqlResults: any, questionnaire: R4.IQuestionnaire): R4.IQuestionnaire {
 
   // Object Containing Questionnaire Items 
   let questionnaireItems: any = questionnaire.item;
-  console.log((questionnaireItems));
 
   // Get Non-Empty Patient Results
   const patientResults = cqlResults.patientResults;
@@ -15,20 +16,18 @@ export default function questionnaireUpdater(cqlResults: any, questionnaire: R4.
     let resourceList = igResources[key];
     if (resourceList.length > 0) {
 
-      // Accomodate for the return of multiple resources (For now this will just iterate over 1 resource)
+      // Accomodate for the return of multiple resources (for now this will just iterate over 1 resource)
       for (let fhirResource in resourceList) {
 
         // Match the FHIR Object to the Correspinding Questionnaire LinkID
         for (let r in questionnaireItems) {
           let possibleMatch = questionnaireItems[r]["linkId"];
-
           if (possibleMatch === key) {
-            console.log(possibleMatch);
 
+            // Add as an answerOption for the Questionnaire item
             const answerOption = createAnswerOption(resourceList[fhirResource]);
 
             if (!questionnaireItems[r].answerOption) {
-              //console.log([answerOption.valueReference.reference]);
               questionnaireItems[r].answerOption = [answerOption];
             }
             else {

--- a/src/utils/results-processing.ts
+++ b/src/utils/results-processing.ts
@@ -14,31 +14,25 @@ export default function questionnaireUpdater(cqlResults: any, questionnaire: R4.
   for (let key in igResources) {
     let resourceList = igResources[key];
     if (resourceList.length > 0) {
-      // Accomodate for the return of multiple resources (for now this will just iterate over 1 resource)
-      //questionnaireItems.find((r: object) => r['linkId'] === key );
-      //console.log(found);
+      // Find corresponding quesionnaire resource
+      const matchingResource = questionnaireItems.find((element: any) => element.linkId === key);
+      const questionnaireItemIndex = questionnaireItems.indexOf(matchingResource);
 
-      //let ansOpt = resourceList.map(createAnswerOption(resourceList[fhirResource]);
-      //console.log(ansOpt);
-
-      for (let fhirResource in resourceList) {
-        // Match the FHIR Object to the Correspinding Questionnaire LinkID
-        for (let r in questionnaireItems) {
-          let possibleMatch = questionnaireItems[r]['linkId'];
-          if (possibleMatch === key) {
-            // Add as an answerOption for the Questionnaire item
-            const answerOption = createAnswerOption(resourceList[fhirResource]);
-
-            if (!questionnaireItems[r].answerOption) {
-              questionnaireItems[r].answerOption = [answerOption];
-            } else {
-              questionnaireItems[r].answerOption.push(answerOption);
-            }
-          }
-        }
+      // Add answerOption element to questionnaire item
+      const answerOptionArray = resourceList.map(createAnswerOption);
+      if (!matchingResource.answerOption) {
+        matchingResource.answerOption = answerOptionArray;
+      } else {
+        matchingResource.answerOption = matchingResource.answerOption.push.apply(
+          matchingResource.answerOption,
+          answerOptionArray
+        );
       }
+      questionnaireItems[questionnaireItemIndex] = matchingResource;
     }
   }
+
+  // Update questionnaire
   questionnaire.item = questionnaireItems;
   return questionnaire;
 }

--- a/src/utils/results-processing.ts
+++ b/src/utils/results-processing.ts
@@ -1,9 +1,23 @@
-export default function resultsProcessing(cqlResults: object): any {
+export default function resultsProcessing(cqlResults: any): any {
   // TODO: Process FHIR resources returned from CQL Execution
+
+  // Get each nonempty result
+  const patientResults = cqlResults.patientResults;
+  const patientID = Object.keys(patientResults)[0];
+  const igResources = cqlResults.patientResults[patientID];
+
+
+  for (let key in igResources) {
+    let resource = igResources[key];
+    //console.log(resource);
+    if (resource.length > 0){
+      console.log(key);
+      console.log(resource);
+    }
+  }
 
   // Get each nonempty result
   // Get name of expression
   // Match with linkID of questionnaire
-
-  return null;
+  return igResources;
 }

--- a/src/utils/results-processing.ts
+++ b/src/utils/results-processing.ts
@@ -1,10 +1,9 @@
-import { R4 } from "@ahryman40k/ts-fhir-types";
+import { R4 } from '@ahryman40k/ts-fhir-types';
 
 // Filter results by querying proper data from the returned FHIR resources.
 // Modify the answerOptions of the questionnaire to include the results from execution
 export default function questionnaireUpdater(cqlResults: any, questionnaire: R4.IQuestionnaire): R4.IQuestionnaire {
-
-  // Object Containing Questionnaire Items 
+  // Object Containing Questionnaire Items
   let questionnaireItems: any = questionnaire.item;
 
   // Get Non-Empty Patient Results
@@ -15,22 +14,18 @@ export default function questionnaireUpdater(cqlResults: any, questionnaire: R4.
   for (let key in igResources) {
     let resourceList = igResources[key];
     if (resourceList.length > 0) {
-
       // Accomodate for the return of multiple resources (for now this will just iterate over 1 resource)
       for (let fhirResource in resourceList) {
-
         // Match the FHIR Object to the Correspinding Questionnaire LinkID
         for (let r in questionnaireItems) {
-          let possibleMatch = questionnaireItems[r]["linkId"];
+          let possibleMatch = questionnaireItems[r]['linkId'];
           if (possibleMatch === key) {
-
             // Add as an answerOption for the Questionnaire item
             const answerOption = createAnswerOption(resourceList[fhirResource]);
 
             if (!questionnaireItems[r].answerOption) {
               questionnaireItems[r].answerOption = [answerOption];
-            }
-            else {
+            } else {
               questionnaireItems[r].answerOption.push(answerOption);
             }
           }
@@ -42,7 +37,7 @@ export default function questionnaireUpdater(cqlResults: any, questionnaire: R4.
   return questionnaire;
 
   function createAnswerOption(fhirObject: any) {
-    let referenceLocation = ( fhirObject._json.resourceType + "/" + fhirObject.id.value );
+    let referenceLocation = fhirObject._json.resourceType + '/' + fhirObject.id.value;
     // Format answer option
     const referenceObject = {
       valueReference: {
@@ -52,5 +47,4 @@ export default function questionnaireUpdater(cqlResults: any, questionnaire: R4.
     };
     return referenceObject;
   }
-
 }

--- a/src/utils/results-processing.ts
+++ b/src/utils/results-processing.ts
@@ -11,8 +11,13 @@ export default function resultsProcessing(cqlResults: any): any {
     let resource = igResources[key];
     //console.log(resource);
     if (resource.length > 0){
+
       console.log(key);
       console.log(resource);
+
+      // Also take in a questionnaire resource
+      
+
     }
   }
 

--- a/src/utils/results-processing.ts
+++ b/src/utils/results-processing.ts
@@ -10,7 +10,7 @@ export default function questionnaireUpdater(
   // Object Containing Questionnaire Items
   let questionnaireItems = questionnaire.item;
 
-  if (questionnaireItems !== undefined){
+  if (questionnaireItems !== undefined) {
     // Get Non-Empty Patient Results
     const igResources = cqlResults.patientResults[patientId];
     for (let key in igResources) {

--- a/src/utils/results-processing.ts
+++ b/src/utils/results-processing.ts
@@ -2,15 +2,16 @@ import { R4 } from '@ahryman40k/ts-fhir-types';
 
 // Filter results by querying proper data from the returned FHIR resources.
 // Modify the answerOptions of the questionnaire to include the results from execution
-export default function questionnaireUpdater(cqlResults: any, questionnaire: R4.IQuestionnaire): R4.IQuestionnaire {
+export default function questionnaireUpdater(
+  cqlResults: any,
+  questionnaire: R4.IQuestionnaire,
+  patientId: string
+): R4.IQuestionnaire {
   // Object Containing Questionnaire Items
   let questionnaireItems: any = questionnaire.item;
 
   // Get Non-Empty Patient Results
-  const patientResults = cqlResults.patientResults;
-  const patientID = Object.keys(patientResults)[0];
-  const igResources = cqlResults.patientResults[patientID];
-
+  const igResources = cqlResults.patientResults[patientId];
   for (let key in igResources) {
     let resourceList = igResources[key];
     if (resourceList.length > 0) {

--- a/src/utils/results-processing.ts
+++ b/src/utils/results-processing.ts
@@ -15,7 +15,6 @@ export default function questionnaireUpdater(
     const igResources = cqlResults.patientResults[patientId];
     for (let key in igResources) {
       let resourceList = igResources[key];
-      console.log(resourceList);
       if (resourceList.length > 0) {
         // Find corresponding quesionnaire resource
         const matchingResource = questionnaireItems.find(element => element.linkId === key) as R4.IQuestionnaire_Item;

--- a/src/utils/results-processing.ts
+++ b/src/utils/results-processing.ts
@@ -1,25 +1,47 @@
-export default function resultsProcessing(cqlResults: any): any {
+import { R4 } from "@ahryman40k/ts-fhir-types";
+
+export default function questionnaireUpdater(cqlResults: any, questionnaire: R4.IQuestionnaire): any {
   // TODO: Process FHIR resources returned from CQL Execution
+
+  let questionnaireItems: any = questionnaire.item;
+  console.log((questionnaire));
 
   // Get each nonempty result
   const patientResults = cqlResults.patientResults;
+  //console.log(patientResults);
   const patientID = Object.keys(patientResults)[0];
   const igResources = cqlResults.patientResults[patientID];
 
+  //console.log(igResources)
 
   for (let key in igResources) {
     let resource = igResources[key];
     //console.log(resource);
     if (resource.length > 0){
 
-      console.log(key);
-      console.log(resource);
+      //console.log(key);
+      //console.log(resource);
+
+      for (let questionnaireItem in questionnaireItems) {
+        let possibleMatch = questionnaireItems[questionnaireItem]["linkId"];
+        if (possibleMatch === key) {
+          console.log(possibleMatch);
+          console.log(questionnaireItems[questionnaireItem].answerOption);
+          if (questionnaireItems[questionnaireItem].answerOption) {
+            questionnaireItems[questionnaireItem].answerOption.push(resource);
+          }
+          else {
+            questionnaireItems[questionnaireItem].answerOption = resource;
+          }
+        }
+      }
+      console.log(questionnaireItems);
 
       // Also take in a questionnaire resource
       
-
     }
   }
+
 
   // Get each nonempty result
   // Get name of expression

--- a/src/utils/results-processing.ts
+++ b/src/utils/results-processing.ts
@@ -16,25 +16,21 @@ export default function questionnaireUpdater(
     let resourceList = igResources[key];
     if (resourceList.length > 0) {
       // Find corresponding quesionnaire resource
-      const matchingResource = questionnaireItems.find((element: any) => element.linkId === key);
+      const matchingResource = questionnaireItems.find(element => element.linkId === key);
       const questionnaireItemIndex = questionnaireItems.indexOf(matchingResource);
 
       // Add answerOption element to questionnaire item
       const newAnswerOptions = resourceList.map(createAnswerOption);
-      if (!matchingResource.answerOption) {
+      if (matchingResource.answerOption === undefined || matchingResource.answerOption.length === 0) {
         matchingResource.answerOption = newAnswerOptions;
       } else {
-        matchingResource.answerOption = matchingResource.answerOption.push.apply(
-          matchingResource.answerOption,
-          newAnswerOptions
-        );
+        matchingResource.answerOption = matchingResource.answerOption.concat(newAnswerOptions);
       }
       questionnaireItems[questionnaireItemIndex] = matchingResource;
     }
   }
 
   // Update questionnaire
-  questionnaire.item = questionnaireItems;
   return questionnaire;
 }
 

--- a/src/utils/results-processing.ts
+++ b/src/utils/results-processing.ts
@@ -5,6 +5,7 @@ import { R4 } from '@ahryman40k/ts-fhir-types';
 export default function questionnaireUpdater(cqlResults: any, questionnaire: R4.IQuestionnaire): R4.IQuestionnaire {
   // Object Containing Questionnaire Items
   let questionnaireItems: any = questionnaire.item;
+  console.log(cqlResults);
 
   // Get Non-Empty Patient Results
   const patientResults = cqlResults.patientResults;
@@ -35,16 +36,16 @@ export default function questionnaireUpdater(cqlResults: any, questionnaire: R4.
   }
   questionnaire.item = questionnaireItems;
   return questionnaire;
+}
 
-  function createAnswerOption(fhirObject: any) {
-    let referenceLocation = fhirObject._json.resourceType + '/' + fhirObject.id.value;
-    // Format answer option
-    const referenceObject = {
-      valueReference: {
-        reference: referenceLocation,
-        display: fhirObject.code.coding[0].display.value
-      }
-    };
-    return referenceObject;
-  }
+function createAnswerOption(fhirObject: any) {
+  let referenceLocation = fhirObject._json.resourceType + '/' + fhirObject.id.value;
+  // Format answer option
+  const referenceObject = {
+    valueReference: {
+      reference: referenceLocation,
+      display: fhirObject.code.coding[0].display.value
+    }
+  };
+  return referenceObject;
 }

--- a/src/utils/results-processing.ts
+++ b/src/utils/results-processing.ts
@@ -20,13 +20,13 @@ export default function questionnaireUpdater(
       const questionnaireItemIndex = questionnaireItems.indexOf(matchingResource);
 
       // Add answerOption element to questionnaire item
-      const answerOptionArray = resourceList.map(createAnswerOption);
+      const newAnswerOptions = resourceList.map(createAnswerOption);
       if (!matchingResource.answerOption) {
-        matchingResource.answerOption = answerOptionArray;
+        matchingResource.answerOption = newAnswerOptions;
       } else {
         matchingResource.answerOption = matchingResource.answerOption.push.apply(
           matchingResource.answerOption,
-          answerOptionArray
+          newAnswerOptions
         );
       }
       questionnaireItems[questionnaireItemIndex] = matchingResource;

--- a/src/utils/results-processing.ts
+++ b/src/utils/results-processing.ts
@@ -20,7 +20,7 @@ export default function questionnaireUpdater(cqlResults: any, questionnaire: R4.
     if (resource.length > 0){
 
       //console.log(key);
-      //console.log(resource);
+      console.log(resource);
 
       for (let questionnaireItem in questionnaireItems) {
         let possibleMatch = questionnaireItems[questionnaireItem]["linkId"];
@@ -31,7 +31,15 @@ export default function questionnaireUpdater(cqlResults: any, questionnaire: R4.
             questionnaireItems[questionnaireItem].answerOption.push(resource);
           }
           else {
-            questionnaireItems[questionnaireItem].answerOption = resource;
+            let answerOptionArray = [];
+            const newAnswerOption = {
+              valueReference: {
+                reference: resource,
+                display: resource.code
+              }
+            };
+            answerOptionArray.push(newAnswerOption);
+            questionnaireItems[questionnaireItem].answerOption = answerOptionArray;
           }
         }
       }


### PR DESCRIPTION
**Build out `results-processing.ts`:**
1. Extracts out FHIR Objects from the ELM execution
2. Links FHIR Objects to matching item IDs from the Questionnaire
3. Creates an answerOption for each matched resource, which is displayed on the questionnaire

To test:
- Questionnaire should display [object Object] as value for "CancerRelatedSurgicalProcedure" and "TumorMarker" (in the future we should look into modifying Lform to display what we want)
- The console should log the updated Questionnaire resource, which should include `answerOption` fields for "CancerRelatedSurgicalProcedure" and "TumorMarker".