### PR TITLE
Add run-time type checking to loaders

### DIFF
--- a/src/__tests__/fixtures/sample-questionnaire.json
+++ b/src/__tests__/fixtures/sample-questionnaire.json
@@ -1,415 +1,153 @@
 {
   "resourceType": "Questionnaire",
-  "id": "q1",
-  "title": "Home Oxygen Therapy Order Template",
+  "id": "3141",
+  "url": "http://hl7.org/fhir/Questionnaire/3141",
+  "title": "Cancer Quality Forum Questionnaire 2012",
   "status": "draft",
   "subjectType": [
     "Patient"
   ],
-  "date": "2019-03-11",
-  "publisher": "Da Vinci DTR",
-  "extension": [
-    {
-      "url": "http://hl7.org/fhir/StructureDefinition/cqf-library",
-      "valueCanonical": "todo/Library/home-oxygen-logic"
-    }
-  ],
-  "contained": [
-    {
-      "resourceType": "ValueSet",
-      "id": "gender",
-      "identifier": [
-        {
-          "system": "todo",
-          "value": "todo"
-        }
-      ],
-      "name": "Gender",
-      "status": "draft",
-      "description": "Gender",
-      "compose": {
-        "include": [
-          {
-            "system": "todo",
-            "concept": [
-              {
-                "code": "M",
-                "display": "Male"
-              },
-              {
-                "code": "F",
-                "display": "Female"
-              },
-              {
-                "code": "Other",
-                "display": "Other"
-              }
-            ]
-          }
-        ]
-      }
-    }
-  ],
+  "date": "2012-01",
   "item": [
     {
       "linkId": "1",
-      "text": "Patient Information",
+      "code": [
+        {
+          "system": "http://example.org/system/code/sections",
+          "code": "COMORBIDITY"
+        }
+      ],
       "type": "group",
       "item": [
         {
           "linkId": "1.1",
-          "text": "Last Name",
-          "type": "string",
-          "required": true,
-          "extension": [
+          "code": [
             {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "PatientLastName"
-              }
-            }
-          ]
-        },
-        {
-          "linkId": "1.2",
-          "text": "First Name",
-          "type": "string",
-          "required": true,
-          "enableWhen":[
-              {
-                  "question":"1.1",
-                  "operator":"=",
-                  "answerString":"5"
-              },
-              {
-                "question":"1.3",
-                "operator":"=",
-                "answerBoolean":"S"
+              "system": "http://example.org/system/code/questions",
+              "code": "COMORB"
             }
           ],
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "PatientFirstName"
-              }
-            }
-          ]
-        },
-        {
-          "linkId": "1.3",
-          "text": "Middle Initial",
-          "type": "text",
-          "required": false,
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "PatientMiddleInitial"
-              }
-            }
-          ]
-        },
-        {
-          "linkId": "1.4",
-          "text": "Date Of Birth",
-          "type": "date",
-          "required": true,
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "PatientDateOfBirth"
-              }
-            }
-          ]
-        },
-        {
-          "linkId": "1.5",
-          "text": "Gender",
+          "prefix": "1",
           "type": "choice",
-          "required": true,
-          "answerValueSet": "#gender",
-          "extension": [
+          "answerValueSet": "http://hl7.org/fhir/ValueSet/yesnodontknow",
+          "item": [
             {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "PatientGender"
-              }
+              "linkId": "1.1.1",
+              "code": [
+                {
+                  "system": "http://example.org/system/code/sections",
+                  "code": "CARDIAL"
+                }
+              ],
+              "type": "group",
+              "enableWhen": [
+                {
+                  "question": "1.1",
+                  "operator": "=",
+                  "answerCoding": {
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                    "code": "Y"
+                  }
+                }
+              ],
+              "item": [
+                {
+                  "linkId": "1.1.1.1",
+                  "code": [
+                    {
+                      "system": "http://example.org/system/code/questions",
+                      "code": "COMORBCAR"
+                    }
+                  ],
+                  "prefix": "1.1",
+                  "type": "choice",
+                  "answerValueSet": "http://hl7.org/fhir/ValueSet/yesnodontknow",
+                  "item": [
+                    {
+                      "linkId": "1.1.1.1.1",
+                      "code": [
+                        {
+                          "system": "http://example.org/system/code/questions",
+                          "code": "COMCAR00",
+                          "display": "Angina Pectoris"
+                        },
+                        {
+                          "system": "http://snomed.info/sct",
+                          "code": "194828000",
+                          "display": "Angina (disorder)"
+                        }
+                      ],
+                      "prefix": "1.1.1",
+                      "type": "choice",
+                      "answerValueSet": "http://hl7.org/fhir/ValueSet/yesnodontknow"
+                    },
+                    {
+                      "linkId": "1.1.1.1.2",
+                      "code": [
+                        {
+                          "system": "http://snomed.info/sct",
+                          "code": "22298006",
+                          "display": "Myocardial infarction (disorder)"
+                        }
+                      ],
+                      "prefix": "1.1.2",
+                      "type": "choice",
+                      "answerValueSet": "http://hl7.org/fhir/ValueSet/yesnodontknow"
+                    }
+                  ]
+                },
+                {
+                  "linkId": "1.1.1.2",
+                  "code": [
+                    {
+                      "system": "http://example.org/system/code/questions",
+                      "code": "COMORBVAS"
+                    }
+                  ],
+                  "prefix": "1.2",
+                  "type": "choice",
+                  "answerValueSet": "http://hl7.org/fhir/ValueSet/yesnodontknow"
+                }
+              ]
             }
           ]
-        },
-        {
-          "linkId": "1.6",
-          "text": "Medicare ID",
-          "type": "open-choice",
-          "answerOption":[
-            {
-                "valueCoding":{
-                    "system":"http://hl7.org",
-                    "version":"v1.0",
-                    "code":"7B3o9FFa",
-                    "display":"Bounty Chunter"
-                },
-                "initialSelected":false
-            },
-            {
-                "valueCoding":{
-                    "system":"http://fakesystem.org",
-                    "version":"v1.0",
-                    "code":"5oi1oOI23",
-                    "display":"Verbal Autopsy"
-                },
-                "initialSelected":true
-            },
-            {
-                "valueCoding":{
-                    "system":"http://fakesystem.org",
-                    "version":"v1.0",
-                    "code":"4"
-                }
-            },
-            {
-                "valueCoding":{
-                    "system":"http://fakesystem.org",
-                    "version":"v1.0",
-                    "code":"110110001",
-                    "display":"Bip boop"
-                }
-            }
-        ],
-          "required": true,
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "PatientMedicareId"
-              }
-            }
-          ]
-        },
-        {
-            "linkId": "1.7",
-            "text": "Name of Favorite Pet",
-            "repeats":true,
-            "type": "open-choice",
-            "answerOption":[
-              {
-                  "valueCoding":{
-                      "system":"http://hl7.org",
-                      "version":"v1.0",
-                      "code":"7B3o9FFa",
-                      "display":"Fishy Boi"
-                  },
-                  "initialSelected":false
-              },
-              {
-                  "valueCoding":{
-                      "system":"http://fakesystem.org",
-                      "version":"v1.0",
-                      "code":"5oi1oOI23",
-                      "display":"Dogman"
-                  },
-                  "initialSelected":true
-              },
-              {
-                  "valueCoding":{
-                      "system":"http://fakesystem.org",
-                      "version":"v1.0",
-                      "code":"4",
-                      "display":"Yoshi is still out there"
-                  }
-              },
-              {
-                  "valueCoding":{
-                      "system":"http://fakesystem.org",
-                      "version":"v1.0",
-                      "code":"110110001"
-                  }
-              }
-          ],
-            "required": false,
-            "extension": [
-              {
-                "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-                "valueExpression": {
-                  "language": "text/cql",
-                  "expression": "PatientMedicareId"
-                }
-              }
-            ]
-          }
+        }
       ]
     },
     {
-        "linkId": "2",
-        "text": "Lab Tests",
-        "type": "group",
-        "item": [
-          {
-            "linkId": "2.1",
-            "text": "O2 Saturation",
-            "type": "decimal",
-            "readOnly":true,
-            "required": true,
-            "extension": [
-              {
-                "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-                "valueExpression": {
-                  "language": "text/cql",
-                  "expression": "PatientO2Saturation"
-                }
-              }
-            ]
-          },
-          {
-            "linkId": "2.2",
-            "text": "Recieved X-ray",
-            "type": "boolean",
-            "required": true,
-            "extension": [
-              {
-                "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-                "valueExpression": {
-                  "language": "text/cql",
-                  "expression": "RecievedXRay"
-                }
-              }
-            ]
-          },
-          {
-            "linkId": "2.3",
-            "text": "Mile Time",
-            "type": "time",
-            "extension": [
-              {
-                "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-                "valueExpression": {
-                  "language": "text/cql",
-                  "expression": "MileTime"
-                }
-              }
-            ]
-          },
-          {
-            "linkId": "2.4",
-            "text": "Website",
-            "type": "url",
-            "required": false,
-            "extension": [
-              {
-                "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-                "valueExpression": {
-                  "language": "text/cql",
-                  "expression": "Website"
-                }
-              }
-            ]
-          },
-          {
-            "linkId": "2.5",
-            "text": "Favorite Color",
-            "type": "choice",
-            "required": true,
-            "repeats": true,
-            "answerOption":[
+      "linkId": "2",
+      "code": [
+        {
+          "system": "http://example.org/system/code/sections",
+          "code": "HISTOPATHOLOGY"
+        }
+      ],
+      "type": "group",
+      "item": [
+        {
+          "linkId": "2.1",
+          "code": [
+            {
+              "system": "http://example.org/system/code/sections",
+              "code": "ABDOMINAL"
+            }
+          ],
+          "type": "group",
+          "item": [
+            {
+              "linkId": "2.1.2",
+              "code": [
                 {
-                    "valueCoding":{
-                        "system":"http://colors.org",
-                        "version":"v1.30",
-                        "code":"ff0000",
-                        "display":"Red"
-                    },
-                    "initialSelected":true
-                },
-                {
-                    "valueCoding":{
-                        "system":"http://colors.org",
-                        "version":"v1.30",
-                        "code":"0000ff",
-                        "display":"Blue"
-                    },
-                    "initialSelected":false
-                },
-                {
-                    "valueCoding":{
-                        "system":"http://colors.org",
-                        "version":"v1.30",
-                        "code":"00ff00",
-                        "display":"Green"
-                    }
+                  "system": "http://example.org/system/code/questions",
+                  "code": "STADPT",
+                  "display": "pT category"
                 }
-            ],
-            "extension": [
-              {
-                "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-                "valueExpression": {
-                  "language": "text/cql",
-                  "expression": "Color"
-                }
-              }
-            ]
-          },
-          {
-            "linkId": "2.6",
-            "text": "Vitals",
-            "type": "group",
-            "required": true,
-            "item": [
-                {
-                    "linkId": "2.6.1",
-                    "text": "Heartbeat",
-                    "type": "quantity",
-                    "required": true,
-                    "extension": [
-                      {
-                        "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-                        "valueExpression": {
-                          "language": "text/cql",
-                          "expression": "HeartBeat"
-                        }
-                      }
-                    ]
-                },
-                {
-                    "linkId": "2.6.2",
-                    "text": "Blood Pressure",
-                    "type": "attachment",
-                    "required": true,
-                    "extension": [
-                      {
-                        "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-                        "valueExpression": {
-                          "language": "text/cql",
-                          "expression": "BloodPressure"
-                        }
-                      }
-                    ]
-                },
-                {
-                    "linkId": "2.6.3",
-                    "text": "He is havin a good time?",
-                    "type": "dateTime",
-                    "required": true,
-                    "extension": [
-                      {
-                        "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-                        "valueExpression": {
-                          "language": "text/cql",
-                          "expression": "Fun"
-                        }
-                      }
-                    ]
-                }
-            ]
-          }
-        ]
-      }
+              ],
+              "type": "choice"
+            }
+          ]
+        }
+      ]
+    }
   ]
 }

--- a/src/__tests__/loaders/QuestionnaireLoader.test.ts
+++ b/src/__tests__/loaders/QuestionnaireLoader.test.ts
@@ -24,3 +24,15 @@ test('correctly query file for a questionnaire', async () => {
 
   expect(actualQuestionnaire).toEqual(sampleQuestionnaire);
 });
+
+test('invalid Questionnaire file should throw error', async () => {
+  expect(() => {
+    questionnaire.getFromFile('./src/__tests__/fixtures/sample-patient-bundle.json');
+  }).toThrowError();
+});
+
+test('invalid Questionnaire from URL should throw error', async () => {
+  nock(MOCK_URL).get('/').reply(200, { resourceType: 'not a questionnaire' });
+
+  expect(questionnaire.getFromUrl(MOCK_URL)).rejects.toThrowError();
+});

--- a/src/__tests__/loaders/ValueSetLoader.test.ts
+++ b/src/__tests__/loaders/ValueSetLoader.test.ts
@@ -59,3 +59,11 @@ test('seeds ValueSets properly using bundle', async () => {
   const valueSetMap = await valueSetLoader.seedValueSets();
   expect(valueSetMap).toEqual(EXPECTED_MAP);
 });
+
+test('invalid ValueSet should throw error', async () => {
+  nock(MOCK_URL).get('/example-valueset-3').reply(200, {
+    resourceType: 'notavalueset'
+  });
+
+  expect(valueSetLoader.seedValueSets()).rejects.toThrowError();
+});

--- a/src/loaders/QuestionnaireLoader.ts
+++ b/src/loaders/QuestionnaireLoader.ts
@@ -6,17 +6,29 @@ export class QuestionnaireLoader {
   getFromFile(filePath: string): R4.IQuestionnaire {
     //accessing questionnaire folder for questionnaire specified by input
     const json = fs.readFileSync(filePath, 'utf8');
-    const obj = JSON.parse(json) as R4.IQuestionnaire;
-    if (obj && obj.resourceType === 'Questionnaire') {
-      return obj;
-    } else {
-      throw new Error('provided file is not a valid FHIR questionnaire');
+    const obj = JSON.parse(json);
+
+    if (!this.isValidQuestionnaire(obj)) {
+      throw new Error(`${filePath} is not a valid FHIR Questionnaire`);
     }
+
+    return obj as R4.IQuestionnaire;
   }
 
   async getFromUrl(url: string): Promise<R4.IQuestionnaire> {
     // use axios to send GET request and return response data
     const response = await axios.get(url);
-    return response.data;
+
+    if (!this.isValidQuestionnaire(response.data)) {
+      throw new Error(`${url} did not provide a valid FHIR Questionnaire`);
+    }
+
+    return response.data as R4.IQuestionnaire;
+  }
+
+  isValidQuestionnaire(obj: any): boolean {
+    const validQuestionnaire = R4.RTTI_Questionnaire.decode(obj);
+    // Right = valid object
+    return validQuestionnaire.isRight();
   }
 }


### PR DESCRIPTION
Modify ValueSetLoader and QuestionnaireLoader to check validity of the resources before returning. Unit tested everything

Apparently the questionnaire we had in our unit tests wasn't actually valid so I changed it.

to test the behavior, feel free to change some of the resources in public/static to be invalid fhir and it should yell at you.

**WEIRDNESS**: For some reason, the valuesets weren't validating against the interfaces because of the description property not playing nicely with the "markdown" data type (??). I think this is a bug in the typescript library, so I added a workaround and will report the issue to that repo 
