### PR TITLE
Query Expression Name

### DIFF
--- a/src/utils/results-processing.ts
+++ b/src/utils/results-processing.ts
@@ -1,13 +1,5 @@
 import { R4 } from '@ahryman40k/ts-fhir-types';
 
-interface CandidateExpression {
-  url: string;
-  valueExpression: {
-    expression: string;
-    language: string;
-  };
-};
-
 // Filter results by querying proper data from the returned FHIR resources.
 // Modify the answerOptions of the questionnaire to include the results from execution
 export default function questionnaireUpdater(
@@ -17,8 +9,6 @@ export default function questionnaireUpdater(
 ): R4.IQuestionnaire {
   // Object Containing Questionnaire Items
   let questionnaireItems = questionnaire.item;
-  //console.log(questionnaire);
-  //console.log(cqlResults);
   if (questionnaireItems !== undefined) {
     // Get Non-Empty Patient Results
     const igResources = cqlResults.patientResults[patientId];
@@ -26,10 +16,7 @@ export default function questionnaireUpdater(
       let resourceList = igResources[key];
       if (resourceList.length > 0) {
         // Find corresponding quesionnaire resource
-        //console.log(questionnaireItems);
-
-        const matchingResource = questionnaireItems.find( (element:R4.IQuestionnaire_Item) => getExpressionName(element) === key) as R4.IQuestionnaire_Item;
-        console.log(matchingResource);
+        const matchingResource = questionnaireItems.find(element => getExpressionName(element) === key) as R4.IQuestionnaire_Item;
         const questionnaireItemIndex = questionnaireItems.indexOf(matchingResource);
 
         // Add answerOption element to questionnaire item
@@ -61,15 +48,13 @@ function createAnswerOption(fhirObject: any): R4.IQuestionnaire_AnswerOption {
 }
 
 function getExpressionName(item: R4.IQuestionnaire_Item): string | undefined {
-
-  if (item.extension){
+  if (item.extension) {
     const candidateExpression = item.extension.find( (ext: R4.IExtension) => ext.url === 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression') as R4.IExtension;
-    if ( (candidateExpression.valueExpression as R4.IExpression) && (candidateExpression.valueExpression?.expression as) ){
-      //if (candidateExpression.valueExpression.expression)
-      const valueExpressionArray = candidateExpression.valueExpression.expression.split(".");
-      const expressionName = valueExpressionArray[valueExpressionArray.length - 1];
-      console.log(expressionName);
+    if (candidateExpression.valueExpression?.expression) {
+      const expressionArray = candidateExpression.valueExpression.expression.split(".");
+      const expressionName = expressionArray[expressionArray.length - 1];
       return expressionName;
     }
   }
+  return undefined;
 }

--- a/src/utils/results-processing.ts
+++ b/src/utils/results-processing.ts
@@ -18,7 +18,7 @@ export default function questionnaireUpdater(
       let resourceList = igResources[key];
       if (resourceList.length > 0) {
         // Find corresponding quesionnaire resource
-        console.log(questionnaireItems);
+        //console.log(questionnaireItems);
 
         const matchingResource = questionnaireItems.find(element => getExpressionName(element) === key) as R4.IQuestionnaire_Item;
         const questionnaireItemIndex = questionnaireItems.indexOf(matchingResource);
@@ -52,9 +52,23 @@ function createAnswerOption(fhirObject: any): R4.IQuestionnaire_AnswerOption {
 }
 
 function getExpressionName(item: any): string {
-  const expressionName = item.extension[0].valueExpression.expression;
-  const strArray = expressionName.split(".");
-  const last = strArray[strArray.length - 1];
-  console.log(last);
-  return last;
+
+  interface CandidateExpression {
+    url: string;
+    valueExpression: {
+      expression: string;
+      language: string;
+    };
+  };
+  //{ url: string; }
+
+  //const expressionName = item.extension[0].valueExpression.expression;
+  const candidateExpression = item.extension.find( (ext: CandidateExpression) => ext.url === 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression')
+  const valueExpressionArray = candidateExpression.valueExpression.expression.split(".");
+  const expressionName = valueExpressionArray[valueExpressionArray.length - 1];
+  console.log(expressionName);
+  //const strArray = expressionName.split(".");
+  //const last = strArray[strArray.length - 1];
+  //console.log(last);
+  return expressionName;
 }

--- a/src/utils/results-processing.ts
+++ b/src/utils/results-processing.ts
@@ -49,7 +49,7 @@ function createAnswerOption(fhirObject: any): R4.IQuestionnaire_AnswerOption {
 
 function getExpressionName(item: R4.IQuestionnaire_Item): string | undefined {
   if (item.extension) {
-    const candidateExpression = item.extension.find( (ext: R4.IExtension) => ext.url === 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression') as R4.IExtension;
+    const candidateExpression = item.extension.find(ext => ext.url === 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression') as R4.IExtension;
     if (candidateExpression.valueExpression?.expression) {
       const expressionArray = candidateExpression.valueExpression.expression.split(".");
       const expressionName = expressionArray[expressionArray.length - 1];

--- a/src/utils/results-processing.ts
+++ b/src/utils/results-processing.ts
@@ -1,5 +1,13 @@
 import { R4 } from '@ahryman40k/ts-fhir-types';
 
+interface CandidateExpression {
+  url: string;
+  valueExpression: {
+    expression: string;
+    language: string;
+  };
+};
+
 // Filter results by querying proper data from the returned FHIR resources.
 // Modify the answerOptions of the questionnaire to include the results from execution
 export default function questionnaireUpdater(
@@ -20,7 +28,8 @@ export default function questionnaireUpdater(
         // Find corresponding quesionnaire resource
         //console.log(questionnaireItems);
 
-        const matchingResource = questionnaireItems.find(element => getExpressionName(element) === key) as R4.IQuestionnaire_Item;
+        const matchingResource = questionnaireItems.find( (element:R4.IQuestionnaire_Item) => getExpressionName(element) === key) as R4.IQuestionnaire_Item;
+        console.log(matchingResource);
         const questionnaireItemIndex = questionnaireItems.indexOf(matchingResource);
 
         // Add answerOption element to questionnaire item
@@ -51,24 +60,16 @@ function createAnswerOption(fhirObject: any): R4.IQuestionnaire_AnswerOption {
   return referenceObject;
 }
 
-function getExpressionName(item: any): string {
+function getExpressionName(item: R4.IQuestionnaire_Item): string | undefined {
 
-  interface CandidateExpression {
-    url: string;
-    valueExpression: {
-      expression: string;
-      language: string;
-    };
-  };
-  //{ url: string; }
-
-  //const expressionName = item.extension[0].valueExpression.expression;
-  const candidateExpression = item.extension.find( (ext: CandidateExpression) => ext.url === 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression')
-  const valueExpressionArray = candidateExpression.valueExpression.expression.split(".");
-  const expressionName = valueExpressionArray[valueExpressionArray.length - 1];
-  console.log(expressionName);
-  //const strArray = expressionName.split(".");
-  //const last = strArray[strArray.length - 1];
-  //console.log(last);
-  return expressionName;
+  if (item.extension){
+    const candidateExpression = item.extension.find( (ext: R4.IExtension) => ext.url === 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression') as R4.IExtension;
+    if ( (candidateExpression.valueExpression as R4.IExpression) && (candidateExpression.valueExpression?.expression as) ){
+      //if (candidateExpression.valueExpression.expression)
+      const valueExpressionArray = candidateExpression.valueExpression.expression.split(".");
+      const expressionName = valueExpressionArray[valueExpressionArray.length - 1];
+      console.log(expressionName);
+      return expressionName;
+    }
+  }
 }

--- a/src/utils/results-processing.ts
+++ b/src/utils/results-processing.ts
@@ -9,6 +9,7 @@ export default function questionnaireUpdater(
 ): R4.IQuestionnaire {
   // Object Containing Questionnaire Items
   let questionnaireItems = questionnaire.item;
+  
   if (questionnaireItems !== undefined) {
     // Get Non-Empty Patient Results
     const igResources = cqlResults.patientResults[patientId];

--- a/src/utils/results-processing.ts
+++ b/src/utils/results-processing.ts
@@ -9,7 +9,8 @@ export default function questionnaireUpdater(
 ): R4.IQuestionnaire {
   // Object Containing Questionnaire Items
   let questionnaireItems = questionnaire.item;
-
+  //console.log(questionnaire);
+  //console.log(cqlResults);
   if (questionnaireItems !== undefined) {
     // Get Non-Empty Patient Results
     const igResources = cqlResults.patientResults[patientId];
@@ -17,7 +18,9 @@ export default function questionnaireUpdater(
       let resourceList = igResources[key];
       if (resourceList.length > 0) {
         // Find corresponding quesionnaire resource
-        const matchingResource = questionnaireItems.find(element => element.linkId === key) as R4.IQuestionnaire_Item;
+        console.log(questionnaireItems);
+
+        const matchingResource = questionnaireItems.find(element => getExpressionName(element) === key) as R4.IQuestionnaire_Item;
         const questionnaireItemIndex = questionnaireItems.indexOf(matchingResource);
 
         // Add answerOption element to questionnaire item
@@ -46,4 +49,12 @@ function createAnswerOption(fhirObject: any): R4.IQuestionnaire_AnswerOption {
     }
   };
   return referenceObject;
+}
+
+function getExpressionName(item: any): string {
+  const expressionName = item.extension[0].valueExpression.expression;
+  const strArray = expressionName.split(".");
+  const last = strArray[strArray.length - 1];
+  console.log(last);
+  return last;
 }

--- a/src/utils/results-processing.ts
+++ b/src/utils/results-processing.ts
@@ -9,7 +9,7 @@ export default function questionnaireUpdater(
 ): R4.IQuestionnaire {
   // Object Containing Questionnaire Items
   let questionnaireItems = questionnaire.item;
-  
+
   if (questionnaireItems !== undefined) {
     // Get Non-Empty Patient Results
     const igResources = cqlResults.patientResults[patientId];
@@ -17,7 +17,9 @@ export default function questionnaireUpdater(
       let resourceList = igResources[key];
       if (resourceList.length > 0) {
         // Find corresponding quesionnaire resource
-        const matchingResource = questionnaireItems.find(element => getExpressionName(element) === key) as R4.IQuestionnaire_Item;
+        const matchingResource = questionnaireItems.find(
+          element => getExpressionName(element) === key
+        ) as R4.IQuestionnaire_Item;
         const questionnaireItemIndex = questionnaireItems.indexOf(matchingResource);
 
         // Add answerOption element to questionnaire item
@@ -50,9 +52,11 @@ function createAnswerOption(fhirObject: any): R4.IQuestionnaire_AnswerOption {
 
 function getExpressionName(item: R4.IQuestionnaire_Item): string | undefined {
   if (item.extension) {
-    const candidateExpression = item.extension.find(ext => ext.url === 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression') as R4.IExtension;
+    const candidateExpression = item.extension.find(
+      ext => ext.url === 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression'
+    ) as R4.IExtension;
     if (candidateExpression.valueExpression?.expression) {
-      const expressionArray = candidateExpression.valueExpression.expression.split(".");
+      const expressionArray = candidateExpression.valueExpression.expression.split('.');
       const expressionName = expressionArray[expressionArray.length - 1];
       return expressionName;
     }


### PR DESCRIPTION
[OSHRQ-63](https://jira.mitre.org/browse/OSHRQ-63): Created a function controlling the logic for matching the CQL result with the expression name of each questionnaire item, rather than the linkID.


_Before:_ Match CQL result by finding linkID of questionnaire item.
_Now:_ For each questionnaire item, check if the item has an extension. If so, check if it has the candidateExpression URL. If this is the case, take just the expression name substring of `valueExpression.expression`, removing the library name. Then match this expression name to the CQL result.
